### PR TITLE
[COOK-1598] make "create" a _real_ optionnal parameter

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -21,7 +21,6 @@ define :logrotate_app, :enable => true, :frequency => "weekly", :template => "lo
   include_recipe "logrotate"
 
   path = params[:path].respond_to?(:each) ? params[:path] : params[:path].split
-  create = params[:create] ? params[:create] : "644 root adm"
 
   if params[:enable]
 
@@ -34,7 +33,7 @@ define :logrotate_app, :enable => true, :frequency => "weekly", :template => "lo
       backup false
       variables(
         :path => path,
-        :create => create,
+        :create => params[:create],
         :frequency => params[:frequency],
         :rotate => params[:rotate]
       )

--- a/templates/default/logrotate.erb
+++ b/templates/default/logrotate.erb
@@ -7,6 +7,8 @@
   delaycompress
   copytruncate
   notifempty
+<% if @create %>
   create <%= @create %>
+<% end %>
 }
 <% end -%>


### PR DESCRIPTION
"root adm" isn't a standard.

Without this parameter, logrotate re-create file with same permission as previous (best way I think).
