### PR TITLE
Add size and copytruncate parameters

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-define :logrotate_app, :enable => true, :frequency => "weekly", :template => "logrotate.erb", :cookbook => "logrotate" do
+define :logrotate_app, :enable => true, :frequency => "weekly", :size => "", :copytruncate => true, :template => "logrotate.erb", :cookbook => "logrotate" do
   include_recipe "logrotate"
 
   path = params[:path].respond_to?(:each) ? params[:path] : params[:path].split
@@ -35,7 +35,9 @@ define :logrotate_app, :enable => true, :frequency => "weekly", :template => "lo
       variables(
         :path => path,
         :create => create,
+        :copytruncate => params[:copytruncate],
         :frequency => params[:frequency],
+        :size => params[:size],
         :rotate => params[:rotate]
       )
     end

--- a/templates/default/logrotate.erb
+++ b/templates/default/logrotate.erb
@@ -1,12 +1,19 @@
 <% @path.each do |p| -%>
 <%= p %> {
   <%= @frequency %>
+<% if @size -%>
+  size <%= @size %>
+<% end -%>
   missingok
   rotate <%= @rotate %>
   compress
   delaycompress
+<% if @copytruncate -%>
   copytruncate
+<% end -%>
   notifempty
+<% unless @copytruncate -%>
   create <%= @create %>
+<% end -%>
 }
 <% end -%>


### PR DESCRIPTION
Rotating by size needed to be added as it's an often used configuration, and the create option is only used if copytruncate is not present:

logrotate man page for copytruncate option:
"When this option is used, the create option will have no effect, as the old log file stays in place."
