### PR TITLE
Update definitions/logrotate_app.rb

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -35,7 +35,7 @@ define :logrotate_app, :enable => true, :frequency => "weekly", :template => "lo
     template "/etc/logrotate.d/#{params[:name]}" do
       source params[:template]
       cookbook params[:cookbook]
-      mode 0440
+      mode 0644
       owner "root"
       group "root"
       backup false


### PR DESCRIPTION
Logrotate entries are 644 by default in my Ubuntu 12.04 install.  Updating mode to reflect that.

```
vagrant@precise64:/etc/logrotate.d$ ls -l
total 32
-rw-r--r-- 1 root root 173 Apr 20  2012 apt
-rw-r--r-- 1 root root  79 Mar 30  2012 aptitude
-rw-r--r-- 1 root root 232 Apr 12  2012 dpkg
-rw-r--r-- 1 root root  94 Feb  4  2011 ppp
-rw-r--r-- 1 root root 126 Dec  3  2011 redis-server
-rw-r--r-- 1 root root 515 Mar 30  2012 rsyslog
-rw-r--r-- 1 root root 178 Apr  5  2012 ufw
-rw-r--r-- 1 root root 122 Apr 26  2012 upstart
```
