### PR TITLE
Adding ability to add 'su' in logrotate

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -29,7 +29,8 @@ log_rotate_params = {
   :prerotate      => nil,
   :firstaction    => nil,
   :lastaction     => nil,
-  :sharedscripts  => false
+  :sharedscripts  => false,
+  :su_user        => nil
 }
 
 define(:logrotate_app, log_rotate_params) do
@@ -65,6 +66,7 @@ define(:logrotate_app, log_rotate_params) do
         :prerotate     => Array(params[:prerotate]).join("\n"),
         :firstaction   => Array(params[:firstaction]).join("\n"),
         :lastaction    => Array(params[:lastaction]).join("\n"),
+        :su_user       => params[:su_user],
         :options       => options
       )
     end

--- a/templates/default/logrotate.erb
+++ b/templates/default/logrotate.erb
@@ -46,4 +46,7 @@
 <%= @lastaction %>
   endscript
 <%- end %>
+<%- if @su_user %>
+  su <%= @su_user %>
+<%- end %>
 }


### PR DESCRIPTION
Newer versions of logrotate require "su" when directory permissions are either too open or not owned by root. Some users will see the following error:

error: skipping "/path/to/logfile/something.log" because parent directory has insecure permissions (It's world writable or writable by group which is not "root") Set "su" directive in config file to tell logrotate which user/group should be used for rotation.

Adding this functionality into the cookbook.
