### PR TITLE
Remove double quote from the path

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -53,7 +53,7 @@ define(:logrotate_app, log_rotate_params) do
       group    params[:template_group]
       backup   false
       variables(
-        :path          => Array(params[:path]).map { |path| path.to_s.inspect }.join(' '),
+        :path          => Array(params[:path]).map { |path| path.to_s.inspect.tr('"','') }.join(' '),
         :create        => params[:create],
         :frequency     => params[:frequency],
         :size          => params[:size],


### PR DESCRIPTION
Double quote do not permit to have multiple line with the same logrotate configuration.

Juste strip de " from the path so that the erb template print onlt the path itself, and no other character.
