### PR TITLE
Don't re-initialize constants

### DIFF
--- a/libraries/logrotate_config.rb
+++ b/libraries/logrotate_config.rb
@@ -18,7 +18,7 @@
 #
 
 module CookbookLogrotate
-  DIRECTIVES = %w[
+  DIRECTIVES ||= %w[
     compress        copy        copytruncate    daily           dateext
     delaycompress   ifempty     mailfirst       maillast        missingok
     monthly         nocompress  nocopy          nocopytruncate  nocreate
@@ -27,16 +27,16 @@ module CookbookLogrotate
     weekly          yearly
   ]
 
-  VALUES = %w[
+  VALUES ||= %w[
     compresscmd    uncompresscmd  compressext    compressoptions
     create         dateformat     include        mail
     maxage         minsize        rotate         size
     shredcycles    start          tabooext
   ]
 
-  SCRIPTS = %w[firstaction  prerotate  postrotate  lastaction]
+  SCRIPTS ||= %w[firstaction  prerotate  postrotate  lastaction]
 
-  DIRECTIVES_AND_VALUES = DIRECTIVES + VALUES
+  DIRECTIVES_AND_VALUES ||= DIRECTIVES + VALUES
 
   # Helper class for creating configurations
   class LogrotateConfiguration


### PR DESCRIPTION
Chef loads the logrotate library multiple times (noticed while running specs), causing ruby to throw a warning about re-initializing constants. Let's only declare those in the event that they're not already set...
