### PR TITLE
Correct documentation for the default logrotate template.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The definition takes the following params:
 - `template_mode`: the mode to create the logrotate template with (default "0440")
 - `template_owner`: the owner of the logrotate template (default "root")
 - `template_group`: the group of the logrotate template (default "root")
-- `cookbook`: select the template source from the specified cookbook. By default it will use the cookbook where the definition is used.
+- `cookbook`: select the template source from the specified cookbook. By default it will use the template from the logrotate cookbook.
 - `create`: creation parameters for the logrotate "create" config, follows the form "mode owner group". This is an optional parameter, and is nil by default.
 - `postrotate`: lines to be executed after the log file is rotated
 - `prerotate`: lines to be executed before the log file is rotated


### PR DESCRIPTION
The logrotate_app definition defaults to using the template from
the logrotate cookbook, not from the cookbook where it is used.
