### PR TITLE
Strip invalid options rather than throwing fatal

### DIFF
--- a/definitions/logrotate_app.rb
+++ b/definitions/logrotate_app.rb
@@ -43,8 +43,8 @@ define(:logrotate_app, log_rotate_params) do
     invalid_options = options - acceptable_options
 
     unless invalid_options.empty?
-      Chef::Log.error("Invalid options passed to logrotate, stripping options #{invalid_options.join(', ')}")
-      options -= invalid_options
+      Chef::Log.error("Invalid option(s) passed to logrotate: #{invalid_options.join(', ')}")
+      raise
     end
 
     template "/etc/logrotate.d/#{params[:name]}" do

--- a/test/fixtures/cookbooks/fake/recipes/definition.rb
+++ b/test/fixtures/cookbooks/fake/recipes/definition.rb
@@ -28,7 +28,7 @@ end
 
 logrotate_app 'tomcat-myapp-custom-options' do
   path        '/var/log/tomcat/myapp.log'
-  options     %w(missingok delaycompress invalid-option)
+  options     %w(missingok delaycompress)
   frequency   'daily'
   rotate      30
   create      '644 root adm'


### PR DESCRIPTION
Fatal error throw when invalid options are passed to the definition
kills the run, which seems excessive, and worse will kill the daemon
entirely when chef-client is running in daemonized mode. Instead, log
an error and strip any invalid options, then continue the run.
