### PR TITLE
set correct permissions for syslog-directory on ubuntu-systems

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,3 +53,7 @@ default['logrotate']['global'] = {
     'rotate' => 1,
   },
 }
+
+if platform?("ubuntu")
+  default["logrotate"]["global"]["su"] = "root syslog"
+end


### PR DESCRIPTION
applying the global recipe  (logrotate::global) breaks the logrotation on ubuntu-systems. Since it is required to set “su root syslog” the logrotation aborts otherwise with the error “parent directory has insecure permissions”.