### PR TITLE
Update chef_version to >= 15.3 to require unifed_mode works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
           - 'centos-7'
           - 'centos-8'
           - 'fedora-latest'
+          - 'ubuntu-1804'
           - 'ubuntu-2004'
-          - 'ubuntu-2104'
           - 'opensuse-leap-15'
         suite:
           - 'default'

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,7 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport:
   name: dokken
@@ -53,16 +53,16 @@ platforms:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-20.04
+  - name: ubuntu-18.04
     driver:
       image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: ubuntu-21.04
+  - name: ubuntu-20.04
     driver:
-      image: dokken/ubuntu-21.04
+      image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Installs logrotate package and provides a resource for managi
 version           '3.0.0'
 source_url        'https://github.com/sous-chefs/logrotate'
 issues_url        'https://github.com/sous-chefs/logrotate/issues'
-chef_version      '>= 12.15'
+chef_version      '>= 15.3'
 
 supports 'amazon'
 supports 'centos'


### PR DESCRIPTION
This resolves #154 which was missed in #152

In addition:

- Add 18.04 testing back and remove 21.04
- Fix 20.04 to actually use 20.04
- Use current channel for testing

Signed-off-by: Lance Albertson <lance@osuosl.org>
