### PR TITLE
Fix passing options to global path declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This file is used to list changes made in each version of the logrotate cookbook
 
 ## Unreleased
 
+- Fix passing options to global path declarations
+
 ## 3.0.1 - *2021-05-12*
+
+- Update chef_version to >= 15.3 to require unifed_mode works
 
 ## 3.0.0 - *2021-05-10*
 

--- a/libraries/logrotate.rb
+++ b/libraries/logrotate.rb
@@ -36,21 +36,21 @@ module Logrotate
       PARAMETERS_AND_OPTIONS_AND_SCRIPTS ||= PARAMETERS + OPTIONS + SCRIPTS
 
       def parameters_from(hash)
-        hash.select { |k, _| PARAMETERS.include?(k) }
+        hash.sort.select { |k, _| PARAMETERS.include?(k) }.to_h
       end
 
       def options_from(values)
-        values.sort.select { |v| OPTIONS.include?(v) }
+        values.sort.select { |k, v| OPTIONS.include?(k) && v || v.nil? }.map { |k, _| k }
       end
 
       def paths_from(hash)
-        hash.select { |k| !PARAMETERS_AND_OPTIONS_AND_SCRIPTS.include?(k) }.map do |path, config|
-          [path, { 'parameters' => parameters_from(config), 'options' => options_from(config), 'scripts' => scripts_from(config) }]
+        hash.sort.select { |k, _| !PARAMETERS_AND_OPTIONS_AND_SCRIPTS.include?(k) }.map do |path, config|
+          [path, { 'options' => options_from(config), 'parameters' => parameters_from(config), 'scripts' => scripts_from(config) }]
         end.to_h
       end
 
       def scripts_from(hash)
-        hash.select { |k| SCRIPTS.include?(k) }.map do |script, lines|
+        hash.sort.select { |k, _| SCRIPTS.include?(k) }.map do |script, lines|
           [script, lines.respond_to?(:join) ? lines.join("\n") : lines]
         end.to_h
       end

--- a/spec/unit/resources/global_spec.rb
+++ b/spec/unit/resources/global_spec.rb
@@ -33,5 +33,7 @@ describe 'logrotate_global' do
       .with_content(/weekly/)
       .with_content(%r{\/var\/log\/wtmp \{})
       .with_content(/    create 0664 root utmp/)
+      .with_content(/    missingok/)
+      .with_content(/    monthly/)
   end
 end

--- a/templates/logrotate-global.erb
+++ b/templates/logrotate-global.erb
@@ -39,16 +39,27 @@ include <%= inc %>
 # Paths
 <% @paths.each do |path, config| -%>
 <%= path %> {
+    <% unless nil_or_empty?(config['options']) %>
+    # Options
     <% config['options'].each do |opt|-%>
     <%= opt %>
     <% end -%>
+    <% end -%>
+    <% unless nil_or_empty?(config['parameters']) %>
+
+    # Parameters
     <% config['parameters'].each do |k, v| -%>
     <%= k %> <%= v %>
     <% end -%>
-    <% config['scripts'].each do |scripttype, body| -%>
-    <%= scripttype %>
+    <% end -%>
+    <% unless nil_or_empty?(config['scripts']) %>
+
+    # Scripts
+    <% config['scripts'].each do |type, body| -%>
+    <%= type %>
     <%= body %>
     endscript
+    <% end -%>
     <% end -%>
 }
 

--- a/test/cookbooks/test/recipes/global.rb
+++ b/test/cookbooks/test/recipes/global.rb
@@ -1,5 +1,5 @@
 logrotate_global 'logrotate' do
-  options %w(create weekly)
+  options %w(create weekly dateext)
   parameters(
     'rotate' => 4
   )

--- a/test/integration/default/global_spec.rb
+++ b/test/integration/default/global_spec.rb
@@ -6,6 +6,8 @@ describe file('/etc/logrotate.conf') do
   it { should be_a_file }
   its('mode') { should cmp '0644' }
   its('content') { should include 'include /etc/logrotate.d' }
+  its('content') { should include '    missingok' }
+  its('content') { should include '    monthly' }
 end
 
 describe file('/etc/logrotate.d') do


### PR DESCRIPTION
# Description

1. Due to differences between passing options directly as an Array and picking them up from a Hash options were not being generated in the global template for path declarations.
2. Add chefspec and inspec test cases to catch the above.

## Issues Resolved

- #155 

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.