### PR TITLE
Do not sort options as the order can be important

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the logrotate cookbook
 
 ## Unreleased
 
+- Do not sort options as the order can be important
+
 ## 3.0.5 - *2021-11-03*
 
 - Add CentOS Stream 8 to CI pipeline

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -70,5 +70,5 @@ platforms:
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
-      pid_one_command: /bin/systemd
+      pid_one_command: /usr/lib/systemd/systemd
 ...

--- a/libraries/logrotate.rb
+++ b/libraries/logrotate.rb
@@ -40,7 +40,7 @@ module Logrotate
       end
 
       def options_from(values)
-        values.sort.select { |k, v| OPTIONS.include?(k) && v || v.nil? }.map { |k, _| k }
+        values.select { |k, v| OPTIONS.include?(k) && v || v.nil? }.map { |k, _| k }
       end
 
       def paths_from(hash)

--- a/spec/unit/resources/app_spec.rb
+++ b/spec/unit/resources/app_spec.rb
@@ -43,7 +43,7 @@ describe 'logrotate_global' do
         frequency: 'daily',
         path: '"/var/log/tomcat/myapp-custom-options.log"',
         rotate: 30,
-        options: %w(delaycompress missingok),
+        options: %w(missingok delaycompress),
         firstaction: 'echo "hi"'
       )
     end
@@ -52,7 +52,7 @@ describe 'logrotate_global' do
   context 'tomcat-myapp-sharedscripts' do
     it 'creates appropriate logrotate config' do
       expect(chef_run).to enable_logrotate_app('tomcat-myapp-sharedscripts').with(
-        options: %w(compress copytruncate delaycompress missingok notifempty sharedscripts),
+        options: %w(missingok compress delaycompress copytruncate notifempty sharedscripts),
         path: '"/var/log/tomcat/myapp-sharedscripts.log"'
       )
     end


### PR DESCRIPTION
If someone is trying to do something like the following:

```
postrotate
  /usr/bin/systemctl reload named.service > /dev/null 2>&1 || true
endscript
```

The sorting completely breaks this.

Signed-off-by: Lance Albertson <lance@osuosl.org>
