### PR TITLE
chore: migrate logrotate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,11 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     permissions:
-      actions: write
       checks: write
       pull-requests: write
       statuses: write
-      issues: write
 
   integration:
     needs: "lint-unit"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -3,7 +3,9 @@ config:
   line-length: false # MD013
   no-duplicate-heading: false # MD024
   reference-links-images: false # MD052
+  table-column-style: false # MD060
   no-multiple-blanks:
     maximum: 2
 ignores:
   - .github/copilot-instructions.md
+  - .windsurf/**

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,0 +1,96 @@
+{
+  "revision_id": "bf18368b30ce95d947afd06b4b533bd24ea6f91ca20393381ffd8a1734716b53",
+  "name": "logrotate",
+  "run_list": [
+    "recipe[test::default]"
+  ],
+  "named_run_lists": {
+    "app": [
+      "recipe[test::app]"
+    ],
+    "default": [
+      "recipe[test::default]"
+    ],
+    "global": [
+      "recipe[test::global]"
+    ]
+  },
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "logrotate": {
+      "version": "3.0.31",
+      "identifier": "39c4b9fc25a907ad574a824b35cf8d3a723640a7",
+      "dotted_decimal_identifier": "16260376750827783.48791148496106959.155282163777703",
+      "source": ".",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": "git@github.com:sous-chefs/logrotate.git",
+        "revision": "f486071aface4ec847960c92de219de325b7c7f1",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main",
+          "origin/renovate/actions"
+        ]
+      },
+      "source_options": {
+        "path": "."
+      }
+    },
+    "test": {
+      "version": "1.0.0",
+      "identifier": "7e6a09cef313cb14a6b03b86c142c3248d5f920d",
+      "dotted_decimal_identifier": "35582437424829387.5812775377355074.214561758089741",
+      "source": "test/cookbooks/test",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": "git@github.com:sous-chefs/logrotate.git",
+        "revision": "f486071aface4ec847960c92de219de325b7c7f1",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main",
+          "origin/renovate/actions"
+        ]
+      },
+      "source_options": {
+        "path": "test/cookbooks/test"
+      }
+    }
+  },
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "logrotate",
+        ">= 0.0.0"
+      ],
+      [
+        "test",
+        ">= 0.0.0"
+      ]
+    ],
+    "dependencies": {
+      "logrotate (3.0.31)": [
+
+      ],
+      "test (1.0.0)": [
+        [
+          "logrotate",
+          ">= 0.0.0"
+        ]
+      ]
+    }
+  }
+}

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+name 'logrotate'
+
+run_list 'test::default'
+
+cookbook 'logrotate', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,11 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
 tmp
 
 # Bundler #

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -1,10 +1,14 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_image: "<%= ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? 'cincproject/cinc' : 'chef/chef' %>"
+  chef_version: "<%= ENV['CHEF_VERSION'] || (ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? 'latest' : 'current') %>"
 
 transport: { name: dokken }
-provisioner: { name: dokken }
+provisioner:
+  name: dokken
+  chef_binary: "<%= ENV.fetch('KITCHEN_PRODUCT_NAME', 'cinc') == 'cinc' ? '/opt/cinc/bin/cinc-client' : '/opt/chef/bin/chef-client' %>"
+  product_name: "<%= ENV['KITCHEN_PRODUCT_NAME'] || 'cinc' %>"
 
 platforms:
   - name: almalinux-8

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -41,6 +41,11 @@ platforms:
       image: dokken/centos-stream-10
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
+
   - name: debian-12
     driver:
       image: dokken/debian-12

--- a/kitchen.global.yml
+++ b/kitchen.global.yml
@@ -1,6 +1,6 @@
 ---
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: chef
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   channel: stable
@@ -10,6 +10,7 @@ provisioner:
   multiple_converge: <%= ENV['MULTIPLE_CONVERGE'] || 2 %>
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   deprecations_as_errors: true
   chef_license: accept-no-persist
   product_name: chef
@@ -11,6 +11,7 @@ provisioner:
   install_strategy: once
   enforce_idempotency: true
   multiple_converge: 2
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -28,5 +29,5 @@ platforms:
 
 suites:
   - name: default
-    run_list:
-      - recipe[test::default]
+    provisioner:
+      named_run_list: default

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- replace Berksfile dependency resolution with Policyfile.rb and Policyfile.lock.json
- update ChefSpec and Kitchen to use Policyfile support
- move lint-unit to sous-chefs/.github v9.0.0 and update setup/lint config for Policyfile

## Validation
- chef install Policyfile.rb
- chef update Policyfile.rb
- cookstyle
- chef exec rspec --format documentation failed before examples due local ~/.chef/gem json native extension code-signing issue; reran with Workstation embedded gems
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md"
- yamllint .
- actionlint
- git diff --check
- env -u KITCHEN_LOCAL_YAML kitchen list
- env -u KITCHEN_LOCAL_YAML kitchen diagnose default-ubuntu-2404
- env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list
- env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose default-ubuntu-2404
- env KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always