### PR TITLE
ci: pass required slack secrets to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,3 +21,5 @@ jobs:
       token: ${{ secrets.PORTER_GITHUB_TOKEN }}
       supermarket_user: ${{ secrets.CHEF_SUPERMARKET_USER }}
       supermarket_key: ${{ secrets.CHEF_SUPERMARKET_KEY }}
+      slack_bot_token: ${{ secrets.SLACK_BOT_TOKEN }}
+      slack_channel_id: ${{ secrets.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
## Problem

`sous-chefs/.github@9.0.0` declares `slack_bot_token` and `slack_channel_id` as `required: true`. This caller does not pass them, so the reusable workflow fails validation and **every push to `main` ends in `startup_failure`** — release-please never executes and no releases are cut.

## Fix

Pass the two secrets. Both already exist as sous-chefs org secrets with `ALL` repository visibility, so nothing needs creating.

## Notes

Once merged, release-please runs again and will open a release PR if there are releasable commits.

One of 43 sous-chefs cookbooks in this state; this batch covers the ones with green CI on `main`.